### PR TITLE
Remove duplicated tech tree fields

### DIFF
--- a/GameData/SXT/Parts/CoreTech/Utility/floats/part.cfg
+++ b/GameData/SXT/Parts/CoreTech/Utility/floats/part.cfg
@@ -33,8 +33,6 @@ PART
 	attachRules = 1,1,1,1,1
 	
 	// --- standard part parameters ---
-	TechRequired = advLanding
-	entryCost = 0
 	mass = 0.02
 	dragModelType = default
 	maximum_drag = 0.2

--- a/GameData/SXT/Parts/CoreTech/Utility/floats/partMid.cfg
+++ b/GameData/SXT/Parts/CoreTech/Utility/floats/partMid.cfg
@@ -35,8 +35,6 @@ PART
 	attachRules = 1,1,1,1,1
 	
 	// --- standard part parameters ---
-	TechRequired = advLanding
-	entryCost = 0
 	mass = 0.02
 	dragModelType = default
 	maximum_drag = 0.2

--- a/GameData/SXT/Parts/CoreTech/Utility/floats/partOutboard.cfg
+++ b/GameData/SXT/Parts/CoreTech/Utility/floats/partOutboard.cfg
@@ -33,8 +33,6 @@ PART
 	attachRules = 0,1,0,1,1
 	
 	// --- standard part parameters ---
-	TechRequired = advLanding
-	entryCost = 0
 	mass = 0.005
 	dragModelType = default
 	maximum_drag = 0.2


### PR DESCRIPTION
As [reported](http://forum.kerbalspaceprogram.com/index.php?/topic/151129-12-sxt-continued-beta/&page=2#comment-2848287) by KSP forum user BureauJaeger.

Not sure what the proper required tech node should be though ("Stability" or "Advanced Landing"?)