### PR TITLE
Fix CTT Advanced Construction node name

### DIFF
--- a/GameData/SXT/Patches/ModCompatibility/CCT/SXT-CCT.cfg
+++ b/GameData/SXT/Patches/ModCompatibility/CCT/SXT-CCT.cfg
@@ -217,7 +217,7 @@
 }
 @PART[LMkIIAircaftTail]:NEEDS[CommunityTechTree]
 {
-    @TechRequired = advConstructions
+    @TechRequired = advConstruction
 }
 @PART[LMkIAircaftFus]:NEEDS[CommunityTechTree]
 {


### PR DESCRIPTION
Just a typo. Reported by the KSP forum user "CaribeanSoul" and i validated it.

[KSP forum link](http://forum.kerbalspaceprogram.com/index.php?/topic/71992-11-sxt-lacks-stock-extension-sxt-25-10apr16-basic-11-compatibilty/&do=findComment&comment=2883445)