### PR TITLE
Adjust DTS-R4 and Komm-16 to match stock

### DIFF
--- a/GameData/SXT/Parts/Probes/Command/Dontstay/partAntenna.cfg
+++ b/GameData/SXT/Parts/Probes/Command/Dontstay/partAntenna.cfg
@@ -42,9 +42,9 @@ PART
 	{
 		name = ModuleDataTransmitter
 		antennaType = DIRECT
-		packetInterval = 0.4
+		packetInterval = 0.6
 		packetSize = 2
-		packetResourceCost = 10.0
+		packetResourceCost = 12.0
 		requiredResource = ElectricCharge
 		// DeployFxModules = 0
 		antennaPower = 500000

--- a/GameData/SXT/Parts/Probes/Command/probe/AntennaTube.cfg
+++ b/GameData/SXT/Parts/Probes/Command/probe/AntennaTube.cfg
@@ -42,8 +42,8 @@ PART
 	{
 		name = ModuleDataTransmitter
 		antennaType = DIRECT
-		packetInterval = 0.1
-		packetSize = 0.125
+		packetInterval = 0.4
+		packetSize = 2
 		packetResourceCost = 12
 		requiredResource = ElectricCharge
 		DeployFxModules = 0


### PR DESCRIPTION
The tube antenna had a packet size of only 0.125 (1/16th normal), but had the same cost per packet, so it was 16x more expensive in terms of EC usage to use it for data transmission.

These changes bring those two antennas inline with the rest of the stock antennas (in terms of packet sizes, transmission speeds, costs per unit of transmission).

---

Stock Antennas

Transmit speed and cost per unit:

| Part Name | Pkt Interval | Pkt Size | Pkt Cost | Transmit Rate | Cost per Unit |
|:---:|:---:|:---:|:---:|:---:|:---:|
| pods          | 1.00 | 2 | 12 |  2.00 |  6.00 |
| Comm-16       | 0.60 | 2 | 12 |  3.33 |  6.00 |
| Comm-16S      | 0.60 | 2 | 12 |  3.33 |  6.00 |
| Comm DTS-M1   | 0.35 | 2 | 12 |  5.71 |  6.00 |
| Comm HG-55    | 0.15 | 3 | 20 | 20.00 |  6.67 |
| Comm 88-88    | 0.10 | 2 | 20 | 20.00 | 10.00 |
| HG-5          | 0.35 | 2 | 18 |  5.71 |  9.00 |
| RA-2          | 0.35 | 1 | 24 |  2.86 | 24.00 |
| RA-15         | 0.35 | 2 | 24 |  5.71 | 12.00 |
| RA-100        | 0.35 | 4 | 24 | 11.43 |  6.00 |