### PR TITLE
fixed "title = title = "

### DIFF
--- a/GameData/SXT/Parts/Aviation/Aero/Wing/partLarge.cfg
+++ b/GameData/SXT/Parts/Aviation/Aero/Wing/partLarge.cfg
@@ -19,7 +19,7 @@ PART
 	cost = 2800 // 680
 	category = Aero
 	subcategory = 0
-	title = title = FAT-460 Super-Lift Aeroplane Main Wing
+	title = FAT-460 Super-Lift Aeroplane Main Wing
 	manufacturer = WinterOwl Aircraft Emporium
 	description = It was initially a 455, it got dropped. Now it's better, it fulfils a niche and probably also leverages synergies. The responsible kerbals were still fired of course. To our knowledge, they haven't landed yet.
 


### PR DESCRIPTION
This has bothered me for too long. Not sure if fixing it is an option, though, as it will break existing craft.

Just btw, there's more oddities where I'm not sure if a "fix" would be welcome: both large wings have very different properties from stock wings; the 2.5m LF tanks hold only half as much fuel per volume as they could. Would you take PRs about these?