### PR TITLE
Wing fuel & lift

### DIFF
--- a/GameData/SXT/Parts/Aviation/Aero/Wing/partLarge.cfg
+++ b/GameData/SXT/Parts/Aviation/Aero/Wing/partLarge.cfg
@@ -29,6 +29,9 @@ PART
 	// --- node definitions ---
 	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_attach = 0, 0.0, 0.0, 1.0, 0.0, 0.0, 5
+        CoMOffset = -3, -2.8, 0 //in, forward, up
+        CoLOffset = -3, -2.8, 0
+        CoPOffset = -3, -2.8, 0
 
 	// --- standard part parameters ---
 	mass = 1.5

--- a/GameData/SXT/Parts/Aviation/Aero/Wing/partLarge.cfg
+++ b/GameData/SXT/Parts/Aviation/Aero/Wing/partLarge.cfg
@@ -19,7 +19,7 @@ PART
 	cost = 2800 // 680
 	category = Aero
 	subcategory = 0
-	title = title = FAT-460 Super-Lift Aeroplane Main Wing
+	title = FAT-460 Super-Lift Aeroplane Main Wing
 	manufacturer = WinterOwl Aircraft Emporium
 	description = It was initially a 455, it got dropped. Now it's better, it fulfils a niche and probably also leverages synergies. The responsible kerbals were still fired of course. To our knowledge, they haven't landed yet.
 
@@ -55,7 +55,7 @@ PART
 	{
 		name = ModuleLiftingSurface
 		useInternalDragModel = True
-		deflectionLiftCoeff = 20
+		deflectionLiftCoeff = 15
 		dragAtMaxAoA = 2
 		dragAtMinAoA = 0.0
 	}
@@ -64,6 +64,6 @@ PART
 	{
 		 name = LiquidFuel
 		 amount = 0
-		 maxAmount = 300
+		 maxAmount = 1000
 	}
 }

--- a/GameData/SXT/Parts/Aviation/Aero/Wing/partLarger.cfg
+++ b/GameData/SXT/Parts/Aviation/Aero/Wing/partLarger.cfg
@@ -32,6 +32,10 @@ PART
 	// definition format is Position X, Position Y, Position Z, Up X, Up Y, Up Z
 	node_attach = 0, 0.0, 0.0, 1.0, 0.0, 0.0, 8
 
+        CoMOffset = -4, -1.9, 0 //in, forward, up
+        CoLOffset = -4, -1.9, 0
+        CoPOffset = -4, -1.9, 0
+	
 	// --- standard part parameters ---
 	mass = 4.5
 	thermalMassModifier = 3.0 // 4.0 // the dang things are light, so 3200 kJ/tonne-K

--- a/GameData/SXT/Parts/Aviation/Aero/Wing/partLarger.cfg
+++ b/GameData/SXT/Parts/Aviation/Aero/Wing/partLarger.cfg
@@ -59,7 +59,7 @@ PART
 	{
 		name = ModuleLiftingSurface
 		useInternalDragModel = True
-		deflectionLiftCoeff = 90
+		deflectionLiftCoeff = 45
 		dragAtMaxAoA = 3
 		dragAtMinAoA = 0.3
 	}
@@ -68,6 +68,6 @@ PART
 	{
 		 name = LiquidFuel
 		 amount = 0
-		 maxAmount = 1000
+		 maxAmount = 3000
 	}
 }


### PR DESCRIPTION
all stock wings have deflectionLiftCoeff = (10x wing mass)

Probably one should measure the wing, then set mass & stats according to actual size. I can't measure, though.

Fuel amount has been roughly based on Mass relative to the stock wing. Accurately it would be 1150 and 3450units. I though round numbers would be better, also, the middle.sized wing is visibly slimmer.