### PR TITLE
2.5m LF tank volume

### DIFF
--- a/GameData/SXT/Parts/Aviation/Command/Mk1BEntente/Size2LFfuselageLong.cfg
+++ b/GameData/SXT/Parts/Aviation/Command/Mk1BEntente/Size2LFfuselageLong.cfg
@@ -43,7 +43,7 @@ PART
 	
 	// --- standard part parameters ---
 
-	mass = 1.14
+	mass = 2
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.3

--- a/GameData/SXT/Parts/Aviation/Command/Mk1BEntente/Size2LFfuselageLong.cfg
+++ b/GameData/SXT/Parts/Aviation/Command/Mk1BEntente/Size2LFfuselageLong.cfg
@@ -60,7 +60,7 @@ PART
 	RESOURCE
 	{
 		name = LiquidFuel
-		amount = 1600
-		maxAmount = 1600
+		amount = 3200
+		maxAmount = 3200
 	}
 }

--- a/GameData/SXT/Parts/Aviation/Command/Mk1BEntente/Size2LFfuselageShort.cfg
+++ b/GameData/SXT/Parts/Aviation/Command/Mk1BEntente/Size2LFfuselageShort.cfg
@@ -42,7 +42,7 @@ PART
 	
 	// --- standard part parameters ---
 
-	mass = 1.14
+	mass = 1
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.3
@@ -60,7 +60,7 @@ PART
 	RESOURCE
 	{
 		name = LiquidFuel
-		amount = 800
-		maxAmount = 800
+		amount = 1600
+		maxAmount = 1600
 	}
 }


### PR DESCRIPTION
Short tank is just as long as the stock 1.25m lf tank (0.25t, 400u), long tank is twice as long. This easily resolves to 4 and 8 times the volume.