### PR TITLE
Fixing TweakScale patches

### DIFF
--- a/GameData/SXT/Patches/ModCompatibility/SXT_TweakScale.cfg
+++ b/GameData/SXT/Patches/ModCompatibility/SXT_TweakScale.cfg
@@ -16,6 +16,9 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
 	{
         type = stack
         defaultScale = 3.75
+        // Or it should be:
+        // type = surface
+        // default = 1.25
 	}
 }
 @PART[SXTOsaulNoseCockpitAn225]:NEEDS[TweakScale] 
@@ -611,29 +614,12 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
         defaultScale = 2.5
 	}
 }
-@PART[SXTOsaulNoseCockpitAn225]:NEEDS[TweakScale] 
-{
-	%MODULE[TweakScale]
-	{
-        type = stack
-        defaultScale = 3.75
-	}
-}
 @PART[SXTOsualHullLarge]:NEEDS[TweakScale] 
 {
 	%MODULE[TweakScale]
 	{
         type = stack
         defaultScale = 3.75
-	}
-}
-
-@PART[SXTOsualRadCockpit]:NEEDS[TweakScale] 
-{
-	%MODULE[TweakScale]
-	{
-        type = surface
-        defaultScale = 1.25
 	}
 }
 @PART[SXTOsualRadHull]:NEEDS[TweakScale] 
@@ -902,7 +888,7 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
         type = free
 	}
 }
-@PART[SXTWing*]:NEEDS[TweakScale] // 6 parts
+@PART[SXTWingVeryLarge,SXTWingSmallFolding,SXTWingSmallHalf,SXTWingTipRound]:NEEDS[TweakScale]
 {
 	%MODULE[TweakScale]
 	{
@@ -1050,14 +1036,6 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
     %MODULE[TweakScale]
     {
         type = surface
-    }
-}
-@PART[SXTInlineAirIntake]:NEEDS[TweakScale] 
-{
-    %MODULE[TweakScale]
-    {
-        type = stack
-        defaultScale = 1.25
     }
 }
 @PART[SXTSmallFuselage]:NEEDS[TweakScale] 
@@ -1267,7 +1245,7 @@ TWEAKSCALEEXPONENTS:NEEDS[KAS&TweakScale]
         type = surface
     }
 }
-@PART[SXTtruck*]:NEEDS[TweakScale] // 
+@PART[SXTtruckcabinsmall,SXTtruckmiddleSmall,SXTtruckrearSmall,SXTtruckcabin,SXTtruckmiddle,SXTtruckrear,SXTtruckfueltank]:NEEDS[TweakScale] // 
 {
     %MODULE[TweakScale]
     {


### PR DESCRIPTION
Fixing TweakScale patches to prevent triggering the Fatal Alert from [#34](https://github.com/net-lisias-ksp/TweakScale/issues/34).

This was reported on [Forum](https://forum.kerbalspaceprogram.com/index.php?/topic/179030-14-tweakscale-under-lisias-management-2430-2019-0608/&do=findComment&comment=3615265)

There're more patches being applied with wildcards, but they are not borking anything for now. I opted to not touch what's not broken yet.

This also fixes the Osaul Radial Cockpit (SXTOsualRadCockpit) that got terribly small due a patch. Now the cockpit is size compatible with the other Osaul cockpits.

![Screen Shot 2019-06-10 at 00 21 49](https://user-images.githubusercontent.com/64334/59170604-cbb93f00-8b15-11e9-80b9-9f7f69a0d00f.png)
