### PR TITLE
Fix Typo

### DIFF
--- a/ModuleBounce/InstallChecker.cs
+++ b/ModuleBounce/InstallChecker.cs
@@ -42,7 +42,7 @@ namespace ModuleBounce
     {
         private const string MODNAME = "SXT";
         private const string FOLDERNAME = "SXT";
-        private const string EXPECTEDPATH = FOLDERNAME + "/Plugns";
+        private const string EXPECTEDPATH = FOLDERNAME + "/Plugins";
 
         protected void Start()
         {


### PR DESCRIPTION
Plugins sub-directory had typo.

Decided to make the fix before reporting bug because it was such a small bug.