### PR TITLE
Fixing crew and IVA for the Osaul Radial Cockpit

### DIFF
--- a/GameData/SXT/Parts/Aviation/Hull/Osaul/RadialCockpit.cfg
+++ b/GameData/SXT/Parts/Aviation/Hull/Osaul/RadialCockpit.cfg
@@ -65,12 +65,12 @@ PART
 	
 	// --- internal setup ---
 
-	CrewCapacity = 3
+	CrewCapacity = 4
 
 	INTERNAL
 	{
 		name = kossakint
-		offset = 0 , .8 , 0.17
+		offset = 0 , -.18 , -.87
 	}
 
 	MODULE


### PR DESCRIPTION
I found this misbehaviour on the IVA, and then fixed the IVA position.

On the task, I realised that besides the IVA not being made exactly for the Radial Cockpit, it almost fits and there's no reason to keep it with only three crew members, so I choose to extend it to 4 - I made no game balance considerations, I gone only for practicality and aesthetics.

There's a seat, and there's space, so I choose to use it. :)

Screenshots *BEFORE* the patch:
* ![00-A](https://user-images.githubusercontent.com/64334/71339561-a1b7ef00-2532-11ea-8401-cf9dac47303d.jpg)
* ![01-A](https://user-images.githubusercontent.com/64334/71339562-a1b7ef00-2532-11ea-83c5-e6d414d29054.jpg)
* ![Uploading 02-A.jpg…]()
* ![03-A](https://user-images.githubusercontent.com/64334/71339564-a2508580-2532-11ea-9f0c-e163ad8debcf.jpg)
* ![04-A](https://user-images.githubusercontent.com/64334/71339566-a2508580-2532-11ea-97b9-c7a317faac61.jpg)

Screenshots *AFTER* the patch:
* ![00-B](https://user-images.githubusercontent.com/64334/71339589-b98f7300-2532-11ea-9107-adc75b291524.jpg)
* ![01-B](https://user-images.githubusercontent.com/64334/71339590-b98f7300-2532-11ea-8210-51af875c3f16.jpg)
* ![02-B](https://user-images.githubusercontent.com/64334/71339591-ba280980-2532-11ea-9d92-e60a2837e87a.jpg)
* ![03-B](https://user-images.githubusercontent.com/64334/71339592-ba280980-2532-11ea-8fcf-7036e4ecf120.jpg)
* ![04-B](https://user-images.githubusercontent.com/64334/71339593-ba280980-2532-11ea-9e50-94df6e3228bc.jpg)

