### PR TITLE
Fix cfg syntax errors

### DIFF
--- a/GameData/SXT/Parts/SuperLaunchers/Hull/5mQuadAdaptor/part.cfg
+++ b/GameData/SXT/Parts/SuperLaunchers/Hull/5mQuadAdaptor/part.cfg
@@ -32,8 +32,8 @@ PART
 	title = #LOC.SXT_SXT5mQuadAdaptor_title // TVR-1600XXL Stack Quad-Adapter
 	manufacturer = #LOC.SXT_SXT5mQuadAdaptor_manufacturer // O.M.B. Demolition Enterprises
 	description = #LOC.SXT_SXT5mQuadAdaptor_description // Initially built due to a mis-read procurement form, the TVR-1600XXL units now take up a large portion of O.M.B.'s storage floor-space. It is now being sold under a variety of names, including 'My First Quad Adapter' and 'Self assembly pool', in order to clear the stock. Converts a single 5m stack into four 2.5m stacks.
-	allowSrfAttach, allowCollision
 
+	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,1,1
 
 	stackSymmetry = 3

--- a/GameData/SXT/Parts/SuperLaunchers/Hull/5mQuadAdaptor/size23adapt.cfg
+++ b/GameData/SXT/Parts/SuperLaunchers/Hull/5mQuadAdaptor/size23adapt.cfg
@@ -25,8 +25,8 @@ PART
 	title = #LOC.SXT_SXTsize2to3Adaptor_title // Kerbodyne S3-S2-2430 Adapter
 	manufacturer = #LOC.SXT_SXTsize2to3Adaptor_manufacturer // O.M.B. Demolition Enterprises
 	description = #LOC.SXT_SXTsize2to3Adaptor_description // A version of Kerbodyne's iconic fuel tank that merges size 2 and 3 tanks.
-	allowSrfAttach, allowCollision
 
+	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,1,1
 
 	mass = 0.8

--- a/GameData/SXT/Parts/SuperLaunchers/SaturnV/Stage2Engine.cfg
+++ b/GameData/SXT/Parts/SuperLaunchers/SaturnV/Stage2Engine.cfg
@@ -36,8 +36,8 @@ PART
 	title = #LOC.SXT_SXTSaturnV2Engine_title // TVR-2000XXL Stack Pent-Adapter
 	manufacturer = #LOC.SXT_SXTSaturnV2Engine_manufacturer // O.M.B. Demolition Enterprises
 	description = #LOC.SXT_SXTSaturnV2Engine_description // Initially built due to a mis-read procurement form, the TVR-1600XXL units now take up a large portion of O.M.B.'s storage floor-space. It is now being sold under a variety of names, including 'My First Quad Adaptor' and 'Self Assembly Pool', in order to clear the stock. Converts a single 5m stack into four 2.5m stacks.
-	allowSrfAttach, allowCollision
 
+	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
 	attachRules = 1,1,1,1,1
 
 	stackSymmetry = 3

--- a/GameData/SXT/Patches/ModCompatibility/WIP/Nukes/NFE.cfg
+++ b/GameData/SXT/Patches/ModCompatibility/WIP/Nukes/NFE.cfg
@@ -1,1 +1,1 @@
-SXTnuclearramjet
+// SXTnuclearramjet


### PR DESCRIPTION
Hi @linuxgurugamer,

I've been working on some cfg parser code for KSP-CKAN/CKAN#3525, and I tested it on this mod and found a few minor syntax errors (comments missing `//`).

This pull request fixes them.

Cheers!